### PR TITLE
Update thunderstorm.dialog

### DIFF
--- a/locale/de-de/dialog/condition/thunderstorm.dialog
+++ b/locale/de-de/dialog/condition/thunderstorm.dialog
@@ -1,2 +1,3 @@
 # auto translated from en-us to de-de
 Stürme
+Sturm


### PR DESCRIPTION
The correct german word for storm is "Sturm". ("Stürme" is the plural from storm. so, storms)