### PR TITLE
Update current-condition-expected-location.dialog

### DIFF
--- a/locale/de-de/dialog/current/current-condition-expected-location.dialog
+++ b/locale/de-de/dialog/current/current-condition-expected-location.dialog
@@ -1,3 +1,5 @@
 # auto translated from en-us to de-de
 In {location} sieht es so aus, als gäbe es heute {condition}
 Ja, es wird {condition} in {location} sein
+Ja, es wird in {location} {condition} sein
+Ja, es wird in {location} {condition} erwartet


### PR DESCRIPTION
When you say it as I wrote in position 4  it means: "Yes, in X (location) it will be (as example: rainy)

When you say it as I wrote in position 5  it means: "Yes, in X (location) Y (as example: rain) is expected