### PR TITLE
Update current-condition-expected-location.dialog

### DIFF
--- a/locale/de-de/dialog/current/current-condition-expected-location.dialog
+++ b/locale/de-de/dialog/current/current-condition-expected-location.dialog
@@ -1,3 +1,4 @@
 # auto translated from en-us to de-de
 In {location} sieht es so aus, als gäbe es heute {condition}
-Ja, es wird {condition} in {location} sein
+Ja, es wird in {location} {condition} sein
+Ja, es wird in {location} {condition} vorausgesagt


### PR DESCRIPTION
I wouldn't use the phrase no. 2 ("In {location} sieht es so aus, als gäbe es heute {condition}"), because it seems more like guessing than analyzing.

Phrase no. 3  is ok, when the condition is (as example) rainy. otherwise it would be: "Ja, es wird in X (location) Y (as example: rain) erwartet" (Yes, it's expected that in X (location) will be Y (as example: rain)