### PR TITLE
Update current-condition-expected-local.dialog

### DIFF
--- a/locale/de-de/dialog/current/current-condition-expected-local.dialog
+++ b/locale/de-de/dialog/current/current-condition-expected-local.dialog
@@ -1,3 +1,4 @@
 # auto translated from en-us to de-de
 Ja, heute wird es {condition} sein
 Es sieht so aus, als ob es heute {condition} geben wird
+Es sieht aus, als würde es heute {condition}


### PR DESCRIPTION
No. 4 is fine, when the condition is: "regnen", "schneien", or "stürmisch werden" ("raining", "snowing" or "becoming stormy")

# Description
<!-- Provide a brief description of this PR -->

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->